### PR TITLE
add api reference docs to metabci.brainda.algorithms.deeplearning

### DIFF
--- a/metabci/brainda/algorithms/deep_learning/convca.py
+++ b/metabci/brainda/algorithms/deep_learning/convca.py
@@ -31,8 +31,71 @@ class _CorrLayer(nn.Module):
         return corr
 
 
-@SkorchNet
+@SkorchNet  # TODO: Bug Fix required:  unable to make docs with this wrapper
 class ConvCA(nn.Module):
+    """
+    ConvCA is a neural network designed for SSVEP task based on TRCA algorithm.
+    It uses three convolutional layers to extract input signal features. [1]_
+    And two convolutional layers were used to extract the features of reference signals (the average value
+    of all training data for each class),
+    the correlation coefficients of the features of these two types of signals were calculated as decision values,
+    and the linear layer was used for classification.
+
+    author: Swolf <swolfforever@gmail.com>
+
+    Created on: 2021-9-12
+
+    update log:
+        2023-12-11 by MutexD <wudf@tju.edu.cn>
+
+
+
+    Parameters
+    ----------
+    n_channels: int
+        Lead count for the input signal.
+    n_samples: int
+        Sampling points of the input signal. The value equals sampling rate (Hz) * signal duration (s).
+    n_classes: int
+        The number of classes of input signals to be classified.
+
+    Attributes
+    ----------
+    signal_cnn: torch.nn.Sequential
+        A CNN block for processing input signals
+    template_cnn: torch.nn.Sequential
+        A CNN block for processing template signals
+    corr_layer: torch.nn.Module
+        Correlation Calculate layer
+    flatten_layer: torch.nn.Linear
+        Dense connection layer for classification.
+    fc_layer: torch.nn.Module
+        Reshape input tensor from 3D to 2D
+
+    Examples
+    ----------
+    >>> # for convCA, you will also need a T(reference signal), you can initialize network like
+    >>> # shallownet by estimator = ConvCA(X.shape[1], X.shape[2], 2),
+    >>> # but you need to wrap X and T in a dict like this {'X': X, 'T', T} to train the network
+    >>> # X size: [batch size, number of channels, number of sample points]
+    >>> # T size: [batch size, number of channels, number of classes, number of sample points]
+    >>> num_classes = 2
+    >>> num_sub_bands = 3
+    >>> estimator = ConvCA(X.shape[1], X.shape[2], 2)
+    >>> dict_ = {'X': train_X, 'T': T}
+    >>> estimator.fit(dict_, train_Y)
+
+    See Also
+    ----------
+    _reset_parameters: Initialize the model parameters
+
+    References
+    ----------
+    .. [1] Li Y , Xiang J , Kesavadas T . Convolutional Correlation Analysis for Enhancing the Performance of
+       SSVEP-Based Brain-Computer Interface[J].
+       IEEE Transactions on Neural Systems and Rehabilitation Engineering, 2020.
+
+    """
     def __init__(self, n_channels, n_samples, n_classes):
         # super(ConvCA, self).__init__()
         super().__init__()

--- a/metabci/brainda/algorithms/deep_learning/deepnet.py
+++ b/metabci/brainda/algorithms/deep_learning/deepnet.py
@@ -1,9 +1,6 @@
 """
-Deep4Net.
-Modified from https://github.com/braindecode/braindecode/blob/master/braindecode/models/deep4.py
- -author: Xie YT
- -Created on: 2022-07-02
- -update log: ...
+ Deep4Net.
+ Modified from https://github.com/braindecode/braindecode/blob/master/braindecode/models/deep4.py
 
 """
 
@@ -25,20 +22,44 @@ from .base import (
 )
 
 
-@SkorchNet
+@SkorchNet  # TODO: Bug Fix required:  unable to make docs with this wrapper
 class Deep4Net(nn.Sequential):
-    """Deep ConvNet model from Schirrmeister et al 2017.
+    """
+    DeepNet was inspired by the successful neural network architecture in computer vision.
+    DeepNet has two convolutional layers similar to ShallowNet to handle temporal convolution and
+    spatial filtering. [1]_
+    In addition to these two convolutional layers,
+    DeepNet has improved its learning capability by adding three additional convolutional layers
+    and a maximum pooling layer.
+    DeepNet also leverages the batch normalization and dropout layers to accelerate and avoid over-fitting during model
+    training. DeepNet employs an exponential linear unit (ELU) as the activation function.
 
-    Model described in [Schirrmeister2017]_.
+    author: Xie YT <xyt_998@tju.edu.cn>
+
+    Created on: 2022-07-02
+
+    update log:
+        2023-12-11 by MutexD <wudf@tju.edu.cn>
 
     Parameters
     ----------
-    n_channels : int
-        XXX
+    n_channels: int
+        Lead count for the input signal.
+    n_samples: int
+        Sampling points of the input signal. The value equals sampling rate (Hz) * signal duration (s).
+    n_classes: int
+        The number of classes of input signals to be classified.
+
+    Examples
+    ----------
+    >>> # X size: [batch size, number of channels, number of sample points]
+    >>> num_classes = 2
+    >>> estimator = Deep4Net(X.shape[1], X.shape[2], num_classes)
+    >>> estimator.fit(X[train_index], y[train_index])
 
     References
     ----------
-    .. [Schirrmeister2017] Schirrmeister, R. T., Springenberg, J. T., Fiederer,
+    .. [1] Schirrmeister, R. T., Springenberg, J. T., Fiederer,
        L. D. J., Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F.
        & Ball, T. (2017).
        Deep learning with convolutional neural networks for EEG decoding and
@@ -46,9 +67,6 @@ class Deep4Net(nn.Sequential):
        Human Brain Mapping , Aug. 2017.
        Online: http://dx.doi.org/10.1002/hbm.23730
 
-    -author: Xie YT
-    -Created on: 2022-07-02
-    -update log: ...
 
     """
 

--- a/metabci/brainda/algorithms/deep_learning/eegnet.py
+++ b/metabci/brainda/algorithms/deep_learning/eegnet.py
@@ -61,23 +61,61 @@ class SeparableConv2d(nn.Module):
         return self.model(X)
 
 
-@SkorchNet
+@SkorchNet  # TODO: Bug Fix required:  unable to make docs with this wrapper
 class EEGNet(nn.Module):
     """
-    Modified from https://github.com/vlawhern/arl-eegmodels/blob/master/EEGModels.py
 
-    near exactly the same one.
+    EEGNet is a general EEG deep learning model which performs well in multiple BCI paradigms.
+    The EEGNet architecture includes batch regularization, dropout, and ELU structures.
+    Several different types of convolutional layers are cleverly designed in EEGNet,
+    such as Deep-wise Convolution and Separable Convolution. By applying these convolution layers,
+    you can effectively reduce the number of parameters to be fitted and speed up training. [1]_
 
-    Assuming the input is a 1-second EEG signal sampled at 128Hz.
-    EEGNet Settings:
-    Parameter     vlawhern
-    kernel_time   64
-    n_filter      8
-    D             2
+    author: Swolf <swolfforever@gmail.com>
 
-    Add max norm constraint on convolutional layers and classification layer.
+    Created on: 2021-1-23
 
-    Remove softmax layer with cross entropy loss in pytorch.
+    update log:
+        2023-12-11 by MutexD <wudf@tju.edu.cn>
+
+    Parameters
+    ----------
+    n_channels: int
+        Lead count for the input signal.
+    n_samples: int
+        Sampling points of the input signal. The value equals sampling rate (Hz) * signal duration (s).
+    n_classes: int
+        The number of classes of input signals to be classified.
+
+    Attributes
+    ----------
+    step1: torch.nn.Sequential
+        First convolution layer
+    step2: torch.nn.Sequential
+        Second convolution layer
+    step3: torch.nn.Sequential
+        Pooling Layer and Flattening operation
+    fc_layer: torch.nn.Linear
+        linear connection layer for classification.
+    model: torch.nn.Sequential
+        stacked model layers
+
+    See Also
+    ----------
+    _reset_parameters: Initialize the model parameters
+
+    Examples
+    ----------
+    >>> # X size: [batch size, number of channels, number of sample points]
+    >>> num_classes = 2
+    >>> estimator = EEGNet(X.shape[1], X.shape[2], num_classes)
+    >>> estimator.fit(X[train_index], y[train_index])
+
+    References
+    ----------
+    .. [1] Lawhern V J , Solon A J , Waytowich N R , et al. EEGNet: A Compact Convolutional Network for EEG-based
+       Brain-Computer Interfaces[J]. Journal of Neural Engineering, 2018, 15(5):056013.1-056013.17.
+
     """
 
     def __init__(self, n_channels, n_samples, n_classes):

--- a/metabci/brainda/algorithms/deep_learning/guney_net.py
+++ b/metabci/brainda/algorithms/deep_learning/guney_net.py
@@ -17,18 +17,58 @@ from .base import (
 )
 
 
-@SkorchNet
+@SkorchNet  # TODO: Bug Fix required:  unable to make docs with this wrapper
 class GuneyNet(nn.Module):
     """
-    Guney's network for decoding SSVEP.
-    They used two stages to train the network.
 
-    The first stage is with all training data in the dataset.
-    lr: 1e-4, batch_size: 100, l2_regularization: 1e-3, epochs: 1000
+    GuneyNet is a neural network specifically designed for the SSVEP task. [1]_
+    The SSVEP paradigm has the characteristic of harmonic correspondence,
+    and in addition to the frequency signature of the SSVEP can be observed at the fundamental
+    frequency of the stimulus, the corresponding can also be observed at the double frequency up to the sixth frequency.
+    The responses of different frequencies have different characteristics,
+    and the responses of the same stimulus at lower frequencies usually have larger amplitudes.
+    But high-octave responses tend to be less disturbed by other ongoing brain activity,
+    and they tend to exhibit relatively high signal-to-noise ratios.
 
-    The second stage is a fine-tuning process with each subject's training data.
-    lr: 1e-4, batch_size: full size, l2_regularization: 1e-3, epochs: 1000
-    spatial_dropout=time1_dropout=0.6
+    GuneyNet first synthesizes the results of multiple filter sub-bands through a convolutional network layer,
+    then extracts the information on multiple electrodes through spatial convolution similar to the previous network,
+    uses two temporal convolution layers to extract temporal information,
+    and finally uses a linear layer to classify the extracted features.
+
+    author: Xie YT <xyt_998@tju.edu.cn>
+
+    Created on: 2022-07-02
+
+    update log:
+        2023-12-11 by MutexD <wudf@tju.edu.cn>
+
+
+    Parameters
+    ----------
+
+    n_channels: int
+        Lead count for the input signal.
+    n_samples: int
+        Sampling points of the input signal. The value equals sampling rate (Hz) * signal duration (s).
+    n_classes: int
+        The number of classes of input signals to be classified.
+
+    Examples
+    ----------
+    >>> # X size: [batch size, number of channels, number of sample points]
+    >>> num_classes = 2
+    >>> num_sub_bands = 3
+    >>> estimator = GuneyNet(X.shape[2], X.shape[3], num_classes, num_sub_bands)
+    >>> estimator.fit(X[train_index], y[train_index])
+
+    See Also
+    ----------
+    _reset_parameters: Initialize the model parameters
+
+    References
+    ----------
+    .. [1] Guney O B , Oblokulov M , Ozkan H . A Deep Neural Network for SSVEP-based
+       Brain Computer Interfaces[J]. 2020.
     """
 
     def __init__(self, n_channels, n_samples, n_classes, n_bands):

--- a/metabci/brainda/algorithms/deep_learning/shallownet.py
+++ b/metabci/brainda/algorithms/deep_learning/shallownet.py
@@ -34,8 +34,70 @@ class SafeLog(nn.Module):
         return torch.log(torch.clamp(X, min=self.eps))
 
 
-@SkorchNet
+@SkorchNet  # TODO: Bug Fix required:  unable to make docs with this wrapper
 class ShallowNet(nn.Module):
+
+    """
+    ShallowNet is a neural network structure specifically designed for motion imagination (MI) tasks,
+    decoding the band power features in MI signals. [1]_
+
+    ShallowNet uses two convolution layers to simulate bandpass filtering and spatial filtering in the FBCSP(Filter
+    Bank Common Spatial Pattern) algorithm.
+    The first layer in ShallowNet performs convolution on the time dimension,
+    convolving the EEG data in each channel separately to extract time domain features.
+    The second layer integrates the features of each channel extracted by the first layer through convolution
+    across channels. ShallowNet also designed an average pooling layer after the two convolution layers,
+    and two activation functions :math:`x^2` and  :math:`log(x)` respectively is applied before and after
+    the average pool layer,
+    referring to experimental log-variance calculations in the FBCSP algorithm.
+
+    author: Swolf <swolfforever@gmail.com>
+
+    Created on: 2021-07-06
+
+    update log:
+        2023-12-11 by MutexD <wudf@tju.edu.cn>
+
+    Parameters
+    ----------
+    n_channels: int
+        Lead count for the input signal.
+    n_samples: int
+        Sampling points of the input signal. The value equals sampling rate (Hz) * signal duration (s).
+    n_classes: int
+        The number of classes of input signals to be classified.
+
+    Attributes
+    ----------
+    step1: torch.nn.Sequential
+        First convolution layer
+    step2: torch.nn.Sequential
+        Second convolution layer
+    step3: torch.nn.Sequential
+        Pooling Layer and Flattening operation
+    fc_layer: torch.nn.Linear
+        linear connection layer for classification.
+    model: torch.nn.Sequential
+        stacked model layers
+
+
+    Examples
+    ----------
+    >>> # X size: [batch size, number of channels, number of sample points]
+    >>> num_classes = 2
+    >>> estimator = ShallowNet(X.shape[1], X.shape[2], num_classes)
+    >>> estimator.fit(X[train_index], y[train_index])
+
+    See Also
+    ----------
+    _reset_parameters: Initialize the model parameters
+
+    References
+    ----------
+    .. [1] Schirrmeiste R T , Springenberg J T , Fiedere L , et al. Deep learning with convolutional neural networks
+       for EEG decoding and visualization[J]. Human Brain Mapping, 2017.
+    """
+
     def __init__(self, n_channels: int, n_samples: int, n_classes: int):
         # super(ShallowNet, self).__init__()
         super().__init__()


### PR DESCRIPTION
add API reference docs to metabci.brainda.algorithms.deeplearning

Classes in deeplearning models have **SkorchNet** wrappers, this may cause docs _can`t be_ make properly in **Sphinx**. 

Further bug fixes are required.