### PR TITLE
Fix data hook bug in BaseTimeEncodingParadigm

### DIFF
--- a/metabci/brainda/paradigms/base.py
+++ b/metabci/brainda/paradigms/base.py
@@ -702,6 +702,13 @@ class BaseTimeEncodingParadigm(BaseParadigm):
                                 }
                             )
 
+                            if self._data_hook:
+                                unit_X, unit_y, meta, caches = self._data_hook(
+                                    unit_X, unit_y, meta, caches)
+                            elif hasattr(dataset, "data_hook"):
+                                unit_X, unit_y, meta, caches = dataset.data_hook(
+                                    unit_X, unit_y, meta, caches)
+
                             # collecting data
                             pre_X = Xs.get(event_name)
                             if pre_X is not None:
@@ -724,13 +731,6 @@ class BaseTimeEncodingParadigm(BaseParadigm):
                                 )
                             else:
                                 metas[event_name] = meta
-
-                            if self._data_hook:
-                                Xs, ys, metas, caches = self._data_hook(
-                                    Xs, ys, metas, caches)
-                            elif hasattr(dataset, "data_hook"):
-                                Xs, ys, metas, caches = dataset.data_hook(
-                                    Xs, ys, metas, caches)
         return Xs, ys, metas
 
     @verbose


### PR DESCRIPTION
ERROR: When apply the paradigm that inherit from BaseTimeEncodingParadigm, using the data hook may cause a error. In the last version, the data hook input X is a Dict type with a deep list as value. This X can not be filtered using Scipy filter.

SOLUTION: Considering the purpose of the  data hook is do some process on single epoch (minimal data unit), I changed its input as unit_x and unit_y, which is a 2_D array-like type that can be filtered.